### PR TITLE
Support child ViewModels

### DIFF
--- a/KMMViewModel.xcodeproj/project.pbxproj
+++ b/KMMViewModel.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		1D198B302933C01800EF778D /* KMMVMViewModelScope.h in Headers */ = {isa = PBXBuildFile; fileRef = 1D198B2E2933C01800EF778D /* KMMVMViewModelScope.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1D198B312933C01800EF778D /* KMMViewModelCoreObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = 1D198B2F2933C01800EF778D /* KMMViewModelCoreObjC.m */; };
 		1D198B322933C04400EF778D /* KMMViewModelCoreObjC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D198B272933BFD900EF778D /* KMMViewModelCoreObjC.framework */; };
+		1D6641DD2A5175C3000180D7 /* ChildViewModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D6641DC2A5175C3000180D7 /* ChildViewModels.swift */; };
 		1DDAF21E293545DD0049C114 /* KMMViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DDAF21D293545DD0049C114 /* KMMViewModel.swift */; };
 /* End PBXBuildFile section */
 
@@ -49,6 +50,7 @@
 		1D198B292933BFD900EF778D /* KMMViewModelCoreObjC.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = KMMViewModelCoreObjC.h; sourceTree = "<group>"; };
 		1D198B2E2933C01800EF778D /* KMMVMViewModelScope.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KMMVMViewModelScope.h; sourceTree = "<group>"; };
 		1D198B2F2933C01800EF778D /* KMMViewModelCoreObjC.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KMMViewModelCoreObjC.m; sourceTree = "<group>"; };
+		1D6641DC2A5175C3000180D7 /* ChildViewModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChildViewModels.swift; sourceTree = "<group>"; };
 		1DDAF21D293545DD0049C114 /* KMMViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KMMViewModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -105,6 +107,7 @@
 			children = (
 				1D0DA80129336AD40057DDAD /* ObservableViewModel.swift */,
 				1DDAF21D293545DD0049C114 /* KMMViewModel.swift */,
+				1D6641DC2A5175C3000180D7 /* ChildViewModels.swift */,
 			);
 			path = KMMViewModelCore;
 			sourceTree = "<group>";
@@ -294,6 +297,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				1DDAF21E293545DD0049C114 /* KMMViewModel.swift in Sources */,
+				1D6641DD2A5175C3000180D7 /* ChildViewModels.swift in Sources */,
 				1D0DA80229336AD40057DDAD /* ObservableViewModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/KMMViewModelCore/ChildViewModels.swift
+++ b/KMMViewModelCore/ChildViewModels.swift
@@ -1,0 +1,185 @@
+//
+//  ChildViewModels.swift
+//  KMMViewModelCore
+//
+//  Created by Rick Clephas on 02/07/2023.
+//
+
+import KMMViewModelCoreObjC
+
+public extension KMMViewModel {
+    
+    private func setChildViewModels(_ keyPath: AnyKeyPath, _ viewModels: AnyHashable?) {
+        if let viewModels = viewModels {
+            observableViewModel(for: self).childViewModels[keyPath] = viewModels
+        } else {
+            observableViewModel(for: self).childViewModels.removeValue(forKey: keyPath)
+        }
+    }
+    
+    private func setChildViewModel<ViewModel: KMMViewModel>(
+        _ viewModel: ViewModel?,
+        at keyPath: AnyKeyPath
+    ) {
+        setChildViewModels(keyPath, observableViewModel(for: viewModel))
+    }
+    
+    /// Stores a reference to the `ObservableObject` for the specified child `KMMViewModel`.
+    func childViewModel<ViewModel: KMMViewModel>(
+        _ viewModel: ViewModel?,
+        at keyPath: KeyPath<Self, ViewModel?>
+    ) -> ViewModel? {
+        setChildViewModel(viewModel, at: keyPath)
+        return viewModel
+    }
+    
+    /// Stores a reference to the `ObservableObject` for the specified child `KMMViewModel`.
+    func childViewModel<ViewModel: KMMViewModel>(
+        _ viewModel: ViewModel,
+        at keyPath: KeyPath<Self, ViewModel>
+    ) -> ViewModel {
+        setChildViewModel(viewModel, at: keyPath)
+        return viewModel
+    }
+    
+    // MARK: Arrays
+    
+    private func setChildViewModels<ViewModel: KMMViewModel>(
+        _ viewModels: [ViewModel?]?,
+        at keyPath: AnyKeyPath
+    ) {
+        setChildViewModels(keyPath, viewModels?.map { viewModel in
+            observableViewModel(for: viewModel)
+        })
+    }
+    
+    /// Stores references to the `ObservableObject`s of the specified child `KMMViewModel`s.
+    func childViewModels<ViewModel: KMMViewModel>(
+        _ viewModels: [ViewModel?]?,
+        at keyPath: KeyPath<Self, [ViewModel?]?>
+    ) -> [ViewModel?]? {
+        setChildViewModels(viewModels, at: keyPath)
+        return viewModels
+    }
+    
+    /// Stores references to the `ObservableObject`s of the specified child `KMMViewModel`s.
+    func childViewModels<ViewModel: KMMViewModel>(
+        _ viewModels: [ViewModel?],
+        at keyPath: KeyPath<Self, [ViewModel?]>
+    ) -> [ViewModel?] {
+        setChildViewModels(viewModels, at: keyPath)
+        return viewModels
+    }
+    
+    /// Stores references to the `ObservableObject`s of the specified child `KMMViewModel`s.
+    func childViewModels<ViewModel: KMMViewModel>(
+        _ viewModels: [ViewModel]?,
+        at keyPath: KeyPath<Self, [ViewModel]?>
+    ) -> [ViewModel]? {
+        setChildViewModels(viewModels, at: keyPath)
+        return viewModels
+    }
+    
+    /// Stores references to the `ObservableObject`s of the specified child `KMMViewModel`s.
+    func childViewModels<ViewModel: KMMViewModel>(
+        _ viewModels: [ViewModel],
+        at keyPath: KeyPath<Self, [ViewModel]>
+    ) -> [ViewModel] {
+        setChildViewModels(viewModels, at: keyPath)
+        return viewModels
+    }
+    
+    // MARK: Sets
+    
+    private func setChildViewModels<ViewModel: KMMViewModel>(
+        _ viewModels: Set<ViewModel?>?,
+        at keyPath: AnyKeyPath
+    ) {
+        setChildViewModels(keyPath, viewModels?.map { viewModel in
+            observableViewModel(for: viewModel)
+        })
+    }
+    
+    /// Stores references to the `ObservableObject`s of the specified child `KMMViewModel`s.
+    func childViewModels<ViewModel: KMMViewModel>(
+        _ viewModels: Set<ViewModel?>?,
+        at keyPath: KeyPath<Self, Set<ViewModel?>?>
+    ) -> Set<ViewModel?>? {
+        setChildViewModels(viewModels, at: keyPath)
+        return viewModels
+    }
+    
+    /// Stores references to the `ObservableObject`s of the specified child `KMMViewModel`s.
+    func childViewModels<ViewModel: KMMViewModel>(
+        _ viewModels: Set<ViewModel?>,
+        at keyPath: KeyPath<Self, Set<ViewModel?>>
+    ) -> Set<ViewModel?> {
+        setChildViewModels(viewModels, at: keyPath)
+        return viewModels
+    }
+    
+    /// Stores references to the `ObservableObject`s of the specified child `KMMViewModel`s.
+    func childViewModels<ViewModel: KMMViewModel>(
+        _ viewModels: Set<ViewModel>?,
+        at keyPath: KeyPath<Self, Set<ViewModel>?>
+    ) -> Set<ViewModel>? {
+        setChildViewModels(viewModels, at: keyPath)
+        return viewModels
+    }
+    
+    /// Stores references to the `ObservableObject`s of the specified child `KMMViewModel`s.
+    func childViewModels<ViewModel: KMMViewModel>(
+        _ viewModels: Set<ViewModel>,
+        at keyPath: KeyPath<Self, Set<ViewModel>>
+    ) -> Set<ViewModel> {
+        setChildViewModels(viewModels, at: keyPath)
+        return viewModels
+    }
+    
+    // MARK: Dictionaries
+    
+    private func setChildViewModels<Key, ViewModel: KMMViewModel>(
+        _ viewModels: [Key : ViewModel?]?,
+        at keyPath: AnyKeyPath
+    ) {
+        setChildViewModels(keyPath, viewModels?.mapValues { viewModel in
+            observableViewModel(for: viewModel)
+        })
+    }
+    
+    /// Stores references to the `ObservableObject`s of the specified child `KMMViewModel`s.
+    func childViewModels<Key, ViewModel: KMMViewModel>(
+        _ viewModels: [Key : ViewModel?]?,
+        at keyPath: KeyPath<Self, [Key : ViewModel?]?>
+    ) -> [Key : ViewModel?]? {
+        setChildViewModels(viewModels, at: keyPath)
+        return viewModels
+    }
+    
+    /// Stores references to the `ObservableObject`s of the specified child `KMMViewModel`s.
+    func childViewModels<Key, ViewModel: KMMViewModel>(
+        _ viewModels: [Key : ViewModel?],
+        at keyPath: KeyPath<Self, [Key : ViewModel?]>
+    ) -> [Key : ViewModel?] {
+        setChildViewModels(viewModels, at: keyPath)
+        return viewModels
+    }
+    
+    /// Stores references to the `ObservableObject`s of the specified child `KMMViewModel`s.
+    func childViewModels<Key, ViewModel: KMMViewModel>(
+        _ viewModels: [Key : ViewModel]?,
+        at keyPath: KeyPath<Self, [Key : ViewModel]?>
+    ) -> [Key : ViewModel]? {
+        setChildViewModels(viewModels, at: keyPath)
+        return viewModels
+    }
+    
+    /// Stores references to the `ObservableObject`s of the specified child `KMMViewModel`s.
+    func childViewModels<Key, ViewModel: KMMViewModel>(
+        _ viewModels: [Key : ViewModel],
+        at keyPath: KeyPath<Self, [Key : ViewModel]>
+    ) -> [Key : ViewModel] {
+        setChildViewModels(viewModels, at: keyPath)
+        return viewModels
+    }
+}

--- a/KMMViewModelCore/ObservableViewModel.swift
+++ b/KMMViewModelCore/ObservableViewModel.swift
@@ -42,29 +42,14 @@ public func observableViewModel<ViewModel: KMMViewModel>(
     }
 }
 
-public extension KMMViewModel {
-    
-    /// Stores a reference to the `ObservableObject` for the specified child `KMMViewModel`.
-    func childViewModel<ViewModel: KMMViewModel>(
-        _ viewModel: ViewModel?,
-        at keyPath: KeyPath<Self, ViewModel?>
-    ) -> ViewModel? {
-        if let viewModel = viewModel {
-            observableViewModel(for: self).childViewModels[keyPath] = observableViewModel(for: viewModel)
-        } else {
-            observableViewModel(for: self).childViewModels.removeValue(forKey: keyPath)
-        }
-        return viewModel
-    }
-    
-    /// Stores a reference to the `ObservableObject` for the specified child `KMMViewModel`.
-    func childViewModel<ViewModel: KMMViewModel>(
-        _ viewModel: ViewModel,
-        at keyPath: KeyPath<Self, ViewModel>
-    ) -> ViewModel {
-        observableViewModel(for: self).childViewModels[keyPath] = observableViewModel(for: viewModel)
-        return viewModel
-    }
+/// Gets the `ObservableObject` for the specified `KMMViewModel`.
+/// - Parameter viewModel: The `KMMViewModel` to wrap in an `ObservableObject`.
+public func observableViewModel<ViewModel: KMMViewModel>(
+    for viewModel: ViewModel?
+) -> ObservableViewModel<ViewModel>? {
+    guard let viewModel = viewModel else { return nil }
+    let observableViewModel = observableViewModel(for: viewModel)
+    return observableViewModel
 }
 
 /// An `ObservableObject` for a `KMMViewModel`.

--- a/README.md
+++ b/README.md
@@ -183,3 +183,28 @@ class TimeTravelViewModel: shared.TimeTravelViewModel {
     @Published var isResetDisabled: Bool = false
 }
 ```
+
+### Child view models
+
+You'll need some additional logic if your `KMMViewModel`s expose child view models.
+
+First make sure to use the `NativeCoroutinesRefinedState` annotation instead of the `NativeCoroutinesState` annotation:
+```kotlin
+class MyParentViewModel: KMMViewModel() {
+    @NativeCoroutinesRefinedState
+    val myChildViewModel: StateFlow<MyChildViewModel?> = MutableStateFlow(null)
+}
+```
+
+After that you should create a Swift extension property using the `childViewModel(_, at:)` function: 
+```swift
+extension MyParentViewModel {
+    var myChildViewModel: MyChildViewModel? {
+        childViewModel(__myChildViewModel, at: \.__myChildViewModel)
+    }
+}
+```
+
+This will prevent your Swift view models from being deallocated too soon. 
+
+> **Note**: for lists, sets and dictionaries containing view models there is `childViewModels(_, at:)`.


### PR DESCRIPTION
Fixes #39

Usage:
```swift
extension MyParentViewModel {
    var myChildViewModel: MyChildViewModel {
        childViewModel(__myChildViewModel, at: \.__myChildViewModel)
    }
}
```